### PR TITLE
Hide included icon sheet container properly

### DIFF
--- a/dist/cinematic.css
+++ b/dist/cinematic.css
@@ -488,6 +488,14 @@ html:-ms-fullscreen {
 
 /*endregion*/
 
+/*region SVG icons*/
+.cinematicjs-icon-container {
+    /* Hide the icon container so it does not mess with the page height */
+    display: none;
+}
+
+/*endregion*/
+
 /*region Helpers*/
 .cinematicjs-hidden {
     visibility: hidden;


### PR DESCRIPTION
The video player loads an SVG icon sheet and adds it to the bottom of the page. This container was previously not hidden and some browsers rendered it with a height higher than 0. We now hide it to ensure its invisible and does not mess with the height of the page.