### PR TITLE
Prevent extremely long title from breaking the layout

### DIFF
--- a/dist/cinematic.css
+++ b/dist/cinematic.css
@@ -92,6 +92,11 @@
     opacity: 0.9;
     transition: opacity .1s ease-in-out;
     text-shadow: 0 0 7px rgba(0, 0, 0, 0.2), 0 0 1em rgba(0, 0, 0, 0.7);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
 
 .cinematicjs-video-header .cinematicjs-video-title.cinematicjs-clickable:hover {


### PR DESCRIPTION
### Description

Restricts video title to two lines.

Ellipsis on a single line is a little restrictive on mobile devices, so we utilize webkit box with line clamping. Seems to be supported by all modern browsers.

**Before:**

![grafik](https://github.com/user-attachments/assets/d07375da-9f78-448c-ae80-fc6785ca017e)

**After:**

![grafik](https://github.com/user-attachments/assets/7ca2b1a4-61ab-4856-88d5-6ec8247c4927)

### Additional Notes

- This PR fixes or works on following ticket(s): [SIRI-1091](https://scireum.myjetbrains.com/youtrack/issue/SIRI-1091)

### Checklist

- [x] Code change has been tested and works locally
- [x] TSC (TypeScript Compiler) has been run and changes are reflected in the dist folder
