### PR TITLE
Accessibility - Fixes critical issues regarding alt texts for `_videoTitleIcon` of CinematicJS

### DIFF
--- a/dist/cinematic.js
+++ b/dist/cinematic.js
@@ -205,6 +205,7 @@ var Cinematic = /** @class */ (function () {
         this._uiWrapper.appendChild(_header);
         this._videoTitleIcon = document.createElement('img');
         this._videoTitleIcon.classList.add('cinematicjs-video-icon');
+        this._videoTitleIcon.setAttribute('alt', 'Video Title Icon');
         _header.appendChild(this._videoTitleIcon);
         this._videoTitle = document.createElement('div');
         this._videoTitle.classList.add('cinematicjs-video-title');

--- a/lib/cinematic.ts
+++ b/lib/cinematic.ts
@@ -297,6 +297,7 @@ class Cinematic {
 
         this._videoTitleIcon = document.createElement('img');
         this._videoTitleIcon.classList.add('cinematicjs-video-icon');
+        this._videoTitleIcon.setAttribute('alt', 'Video Title Icon');
         _header.appendChild(this._videoTitleIcon);
 
         this._videoTitle = document.createElement('div');


### PR DESCRIPTION
### Additional Notes

- This PR fixes or works on following ticket(s): [OX-12027](https://scireum.myjetbrains.com/youtrack/issue/OX-12027)
- This PR is related to PR: https://github.com/scireum/oxomi/pull/12248

### Checklist

- [x] Code change has been tested and works locally
- [ ] TSC (TypeScript Compiler) has been run and changes are reflected in the dist folder
